### PR TITLE
Scaffold new commands to the packages directory by default

### DIFF
--- a/features/scaffold-package.feature
+++ b/features/scaffold-package.feature
@@ -3,7 +3,56 @@ Feature: Scaffold WP-CLI commands
   Scenario: Scaffold a WP-CLI command without tests
     Given an empty directory
 
-    When I run `wp scaffold package foo --skip-tests`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp scaffold package wp-cli/foo --skip-tests`
+    Then STDOUT should contain:
+      """
+      Success: Created package files.
+      """
+    And the packages/vendor/wp-cli/foo/.gitignore file should exist
+    And the packages/vendor/wp-cli/foo/.editorconfig file should exist
+    And the packages/vendor/wp-cli/foo/composer.json file should exist
+    And the packages/vendor/wp-cli/foo/command.php file should exist
+    And the packages/vendor/wp-cli/foo/wp-cli.yml file should exist
+    And the packages/vendor/wp-cli/foo/.travis.yml file should not exist
+
+    When I run `WP_CLI_PACKAGES_DIR=packages wp --require=packages/vendor/wp-cli/foo/command.php hello-world`
+    Then STDOUT should be:
+      """
+      Success: Hello world.
+      """
+
+    When I run `cat packages/vendor/wp-cli/foo/wp-cli.yml`
+    Then STDOUT should contain:
+      """
+      require:
+        - command.php
+      """
+
+    When I run `cat packages/vendor/wp-cli/foo/.gitignore`
+    Then STDOUT should contain:
+      """
+      .DS_Store
+      """
+
+    When I run `cat packages/vendor/wp-cli/foo/.editorconfig`
+    Then STDOUT should contain:
+      """
+      This file is for unifying the coding style for different editors and IDEs
+      """
+
+  Scenario: Scaffold a package with an invalid name
+    Given an empty directory
+
+    When I try `wp scaffold package foo`
+    Then STDERR should be:
+      """
+      Error: 'foo' is an invalid package name. Package scaffold expects '<author>/<package>'.
+      """
+
+  Scenario: Scaffold a WP-CLI command to a custom directory
+    Given an empty directory
+
+    When I run `WP_CLI_PACKAGES_DIR=packages wp scaffold package wp-cli/foo --dir=foo --skip-tests`
     Then STDOUT should contain:
       """
       Success: Created package files.
@@ -15,29 +64,10 @@ Feature: Scaffold WP-CLI commands
     And the foo/wp-cli.yml file should exist
     And the foo/.travis.yml file should not exist
 
-    When I run `wp --require=foo/command.php hello-world`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp --require=foo/command.php hello-world`
     Then STDOUT should be:
       """
       Success: Hello world.
-      """
-
-    When I run `cat foo/wp-cli.yml`
-    Then STDOUT should contain:
-      """
-      require:
-        - command.php
-      """
-
-    When I run `cat foo/.gitignore`
-    Then STDOUT should contain:
-      """
-      .DS_Store
-      """
-
-    When I run `cat foo/.editorconfig`
-    Then STDOUT should contain:
-      """
-      This file is for unifying the coding style for different editors and IDEs
       """
 
   Scenario: Attempt to scaffold the same package twice
@@ -51,13 +81,13 @@ Feature: Scaffold WP-CLI commands
       s
       """
 
-    When I run `wp scaffold package foo --skip-tests`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp scaffold package wp-cli/foo --skip-tests`
     Then STDOUT should contain:
       """
       Success: Created package files.
       """
 
-    When I run `wp scaffold package foo --skip-tests < session`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp scaffold package wp-cli/foo --skip-tests < session`
     And STDERR should contain:
       """
       Warning: File already exists
@@ -70,19 +100,19 @@ Feature: Scaffold WP-CLI commands
   Scenario: Scaffold a WP-CLI command with tests
     Given an empty directory
 
-    When I run `wp scaffold package foo`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp scaffold package wp-cli/foo`
     Then STDOUT should contain:
       """
       Success: Created package files.
       """
-    And the foo/.gitignore file should exist
-    And the foo/.editorconfig file should exist
-    And the foo/composer.json file should exist
-    And the foo/command.php file should exist
-    And the foo/wp-cli.yml file should exist
-    And the foo/.travis.yml file should exist
+    And the packages/vendor/wp-cli/foo/.gitignore file should exist
+    And the packages/vendor/wp-cli/foo/.editorconfig file should exist
+    And the packages/vendor/wp-cli/foo/composer.json file should exist
+    And the packages/vendor/wp-cli/foo/command.php file should exist
+    And the packages/vendor/wp-cli/foo/wp-cli.yml file should exist
+    And the packages/vendor/wp-cli/foo/.travis.yml file should exist
 
-    When I run `wp --require=foo/command.php hello-world`
+    When I run `WP_CLI_PACKAGES_DIR=packages wp --require=packages/vendor/wp-cli/foo/command.php hello-world`
     Then STDOUT should be:
       """
       Success: Hello world.

--- a/inc/ScaffoldPackageCommand.php
+++ b/inc/ScaffoldPackageCommand.php
@@ -11,14 +11,14 @@ class ScaffoldPackageCommand {
 	/**
 	 * Generate the files needed for a basic WP-CLI command.
 	 *
-	 * <dir>
-	 * : Directory for the new package.
-	 *
-	 * [--name=<name>]
-	 * : Name to appear in the composer.json.
+	 * <name>
+	 * : Name for the new package. Expects <author>/<package> (e.g. 'wp-cli/scaffold-package').
 	 *
 	 * [--description=<description>]
 	 * : Human-readable description for the package.
+	 *
+	 * [--dir=<dir>]
+	 * : Specify a destination directory for the command. Defaults to WP-CLI's packages directory.
 	 *
 	 * [--license=<license>]
 	 * : License for the package. Default: MIT.
@@ -33,14 +33,25 @@ class ScaffoldPackageCommand {
 	 */
 	public function package( $args, $assoc_args ) {
 
-		list( $package_dir ) = $args;
-
 		$defaults = array(
-			'name'        => '',
+			'dir'         => '',
 			'description' => '',
 			'license'     => 'MIT',
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
+		$assoc_args['name'] = $args[0];
+
+		$bits = explode( '/', $assoc_args['name'] );
+		if ( 2 !== count( $bits ) || empty( $bits[0] ) || empty( $bits[1] ) ) {
+			WP_CLI::error( "'{$assoc_args['name']}' is an invalid package name. Package scaffold expects '<author>/<package>'." );
+		}
+
+		if ( ! empty( $assoc_args['dir'] ) ) {
+			$package_dir = $assoc_args['dir'];
+		} else {
+			$package_dir = WP_CLI::get_runner()->get_packages_dir_path() . 'vendor/' . $assoc_args['name'];
+		}
+
 		$force = Utils\get_flag_value( $assoc_args, 'force' );
 
 		$package_root = dirname( dirname( __FILE__ ) );


### PR DESCRIPTION
Offer `--dir=<dir>` to specify a different directory